### PR TITLE
Update sign-cert.js

### DIFF
--- a/sign-cert.js
+++ b/sign-cert.js
@@ -10,7 +10,7 @@ const Log = require('./log');
 
 module.exports = function (host) {
 
-  Mkdirp(AppPaths.hostsDir);
+  Mkdirp.sync(AppPaths.hostsDir);
 
   const certPaths = AppPaths.makeCertPaths(host);
 


### PR DESCRIPTION
openssl fails to generate the cert due to missing directory.
Call make-dir-p synchronously to fix the issue.

Fixes #3 